### PR TITLE
Exit cleanly when running in a Docker container

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,12 @@ app.use(errorLogger);
 const swaggerDocument = require('./swagger.json');
 app.use('/docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 
+['SIGINT', 'SIGTERM', 'SIGQUIT'].forEach(signal =>
+    process.on(signal, () => {
+        console.log(`Received ${signal}, terminating`);
+        process.exit();
+    })
+);
 
 // start server
 app.listen(PORT, () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,12 +41,12 @@ app.use('/docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 
 ['SIGINT', 'SIGTERM', 'SIGQUIT'].forEach(signal =>
     process.on(signal, () => {
-        console.log(`Received ${signal}, terminating`);
+        logger.info(`Received ${signal}, terminating`);
         process.exit();
     })
 );
 
 // start server
 app.listen(PORT, () => {
-    console.log('Server is running on port', PORT);
+    logger.info(`Server is running on port ${PORT}`);
 });


### PR DESCRIPTION
Doing a clean shutdown in SIGTERM avoids the 10-second wait-time before
Docker does a forceful SIGKILL.
